### PR TITLE
feat: improve completion triggering

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,64 @@ connection.onInitialize(params => {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: {
         resolveProvider: false,
+        triggerCharacters: [
+          // NOTE: For cases where is valid to expand emmet abbreviations with
+          // special characters
+          '!', // eg. `!` and `!!!` snippets in html or `!important` in css
+          ':', // eg. `w:` should expand to `width: |;`
+          '>', // https://docs.emmet.io/abbreviations/syntax/#child-gt
+          '+', // https://docs.emmet.io/abbreviations/syntax/#sibling
+          '^', // https://docs.emmet.io/abbreviations/syntax/#climb-up
+          '*', // https://docs.emmet.io/abbreviations/syntax/#multiplication
+          ')', // https://docs.emmet.io/abbreviations/syntax/#grouping
+          '.', // https://docs.emmet.io/abbreviations/syntax/#id-and-class
+          ']', // https://docs.emmet.io/abbreviations/syntax/#custom-attributes
+          '@', // https://docs.emmet.io/abbreviations/syntax/#changing-numbering-base-and-direction
+          '}', // https://docs.emmet.io/abbreviations/syntax/#text
+
+          // NOTE: For cases where completion is not triggered by typing a
+          // single character
+          'a',
+          'b',
+          'c',
+          'd',
+          'e',
+          'f',
+          'g',
+          'h',
+          'i',
+          'j',
+          'k',
+          'l',
+          'm',
+          'n',
+          'o',
+          'p',
+          'q',
+          'r',
+          's',
+          't',
+          'u',
+          'v',
+          'w',
+          'x',
+          'y',
+          'z',
+
+          // NOTE: For cases where completion is not triggered by typing a
+          // single character or because numbers cannot be used to trigger
+          // completion
+          '0',
+          '1',
+          '2',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '8',
+          '9',
+        ],
       },
     },
   }


### PR DESCRIPTION
While looking for a solution to #4 I realized that other editors such as Helix don't trigger completions for a single character (eg. `p`) or numeric values (eg. `div>p*2`) and also for special characters (eg. `!`).

I got inspired by this list (https://github.com/aca/emmet-ls/blob/master/src/server.ts#L50-L101) in the emmet-ls repo, but I did and exhaustive test to add all possible characters that should trigger valid completion and avoid the ones that do not.

So with this I fixed a lot of cases where the completion was not triggering without manually telling the editor to ask for completions aside from the multiplication case that was reported.
 
Fixes #4