### PR TITLE
Self closing tags support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ connection.onInitialize(params => {
           ']', // https://docs.emmet.io/abbreviations/syntax/#custom-attributes
           '@', // https://docs.emmet.io/abbreviations/syntax/#changing-numbering-base-and-direction
           '}', // https://docs.emmet.io/abbreviations/syntax/#text
+          '/', // for self-closing tags, eg. `div/` should expand to `<div />|`
 
           // NOTE: For cases where completion is not triggered by typing a
           // single character


### PR DESCRIPTION
This PR just adds the `/` char to the `triggerCharacters` list so when someone does `div/` (should expand to `<div />`) or `SomeComponent/` (should expand to `<SomeComponent />`) shows the completion menu for the self-closing tags.