### PR TITLE
feat: support `includeLanguages` option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -168,8 +168,9 @@ connection.onCompletion(textDocumentPosition => {
   const editorLanguage = document.languageId
   const emmetLanguage = getEmmetMode(editorLanguage) ?? 'html'
 
-  const syntax = !!globalConfig.includeLanguages?.[emmetLanguage]
-    ? globalConfig.includeLanguages[emmetLanguage]
+  const syntax = !!globalConfig.includeLanguages?.[editorLanguage]
+    ? getEmmetMode(globalConfig.includeLanguages[editorLanguage]) ??
+      emmetLanguage
     : emmetLanguage
 
   const position = textDocumentPosition.position

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ const documents = new TextDocuments(TextDocument)
 
 interface GlobalConfig extends VSCodeEmmetConfig {
   extensionsPath?: string[]
+  includeLanguages?: Record<string, string>
 }
 
 let globalConfig: GlobalConfig = {}
@@ -164,12 +165,12 @@ connection.onCompletion(textDocumentPosition => {
     return
   }
 
-  const languageId = document.languageId
-  const syntax = getEmmetMode(languageId) ?? 'html'
+  const editorLanguage = document.languageId
+  const emmetLanguage = getEmmetMode(editorLanguage) ?? 'html'
 
-  if (!syntax) {
-    return
-  }
+  const syntax = !!globalConfig.includeLanguages?.[emmetLanguage]
+    ? globalConfig.includeLanguages[emmetLanguage]
+    : emmetLanguage
 
   const position = textDocumentPosition.position
 


### PR DESCRIPTION
This PR adds support for `includeLanguages` option when configuring the language server.

So, with this you can map a language syntax to another like this:

```
init_options = {
  ---@type table<string, string>
  includeLanguages = {
    javascriptreact = "html",
    typescriptreact = "html",
  },
}
```

And instead of getting the abbreviation `.some` expand to `<div className="some"></div>` it'll expand to `<div class="some"></div>`.

Fixes #29 