### PR TITLE
Make `expandAbbreviation` endpoint language aware

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -182,9 +182,20 @@ connection.onRequest(
   'emmet/expandAbbreviation',
   (params: {
     abbreviation: string
+    language: string
     options: Parameters<typeof expandAbbreviation>[1]
   }) => {
-    return expandAbbreviation(params.abbreviation, params.options)
+    const emmetLanguage = getEmmetMode(params.language) ?? 'html'
+
+    const syntax = !!globalConfig.includeLanguages?.[params.language]
+      ? getEmmetMode(globalConfig.includeLanguages[params.language]) ??
+        emmetLanguage
+      : emmetLanguage
+
+    return expandAbbreviation(params.abbreviation, {
+      syntax,
+      ...params.options,
+    })
   },
 )
 


### PR DESCRIPTION
This PR exposes a `language` option so the `emmet/expandAbbreviation` endpoint can calculate the syntax based on the filetype.

The motivation for this change is https://github.com/olrtg/nvim-emmet/issues/6.