### PR TITLE
avoid completion inside html tags

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import match from '@emmetio/html-matcher'
+import match, { MatchedTag } from '@emmetio/html-matcher'
 import {
   FileType,
   doComplete,
@@ -15,7 +15,6 @@ import path from 'path'
 import util from 'util'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import {
-  Position,
   ProposedFeatures,
   TextDocumentSyncKind,
   TextDocuments,
@@ -126,20 +125,29 @@ connection.onInitialize((params) => {
   }
 })
 
-function isInsideStyleTag(document: TextDocument, position: Position) {
-  const text = document.getText()
-  const offset = document.offsetAt(position)
-
-  const matchedTag = match(text, offset)
-
-  if (!matchedTag) return false
-
-  return matchedTag.name === 'style'
+function isInsideStyleTag(matchedTag: MatchedTag | null): boolean {
+  return matchedTag?.name === 'style'
 }
 
-function getSyntax(document: TextDocument, position: Position) {
-  const editorLanguage = document.languageId
-  const emmetLanguage = isInsideStyleTag(document, position)  
+function isInsideTag(
+  matchedTag: MatchedTag | null,
+  offset: number,
+): boolean {
+  if (!matchedTag) return false
+
+  if (offset > matchedTag.open[0] && offset < matchedTag.open[1]) {
+    return true
+  }
+
+  return (
+    !!matchedTag.close &&
+    offset > matchedTag.close[0] &&
+    offset < matchedTag.close[1]
+  )
+}
+
+function getSyntax(editorLanguage: string, matchedTag: MatchedTag | null) {
+  const emmetLanguage = isInsideStyleTag(matchedTag)
     ? 'css'
     : (getEmmetMode(editorLanguage) ?? 'html')
 
@@ -163,7 +171,13 @@ connection.onCompletion((textDocumentPosition) => {
   if (!document) return
 
   const position = textDocumentPosition.position
-  const syntax = getSyntax(document, position)
+  const text = document.getText()
+  const offset = document.offsetAt(position)
+  const matchedTag = match(text, offset)
+
+  if (isInsideTag(matchedTag, offset)) return
+
+  const syntax = getSyntax(document.languageId, matchedTag)
 
   return doComplete(document, position, syntax, globalConfig)
 })


### PR DESCRIPTION
## Summary
- reuse HTML matcher results so style-tag and tag-boundary checks share a single parse
- skip Emmet completion inside opening or closing tags instead of only attribute values
- send only the editorLanguage into the syntax resolution helper
- add explicit boolean return type to style-tag detection

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68952f7888a08329adc4771e5536d630